### PR TITLE
Branks42 GitHub Specific Fixity Error

### DIFF
--- a/src/components/transfer/stepper/TransferStepperResults.js
+++ b/src/components/transfer/stepper/TransferStepperResults.js
@@ -25,6 +25,7 @@ export default function TransferStepperResults({setActiveStep, selectedDuplicate
   const apiOperationErrors = useSelector(state => state.apiOperationErrors);
   const transferDestinationToken = useSelector(state => state.transferDestinationToken);
   const transferDestinationTarget = useSelector(state => state.transferDestinationTarget);
+  const connection = useSelector(state => state.selectedTarget);
 
   const transferError = apiOperationErrors.find(
     element => element.action === actionCreators.transfer.transferResource.toString());
@@ -53,23 +54,32 @@ export default function TransferStepperResults({setActiveStep, selectedDuplicate
       dispatch(actionCreators.transfer.refreshTransferTarget(transferDestinationTarget, transferDestinationToken))
     }
     else if (transferStatus === 'finished') {
-      const failedFixityMessage = transferData.failed_fixity.length > 0
+      const failedFixityMessage = transferData.failed_fixity.length > 0 && (connection.name === 'github' || transferDestinationTarget === 'github')
         ? <ListItem>
-          <ListItemIcon>
-            <ErrorOutlineIcon style={{ color: colors.warningYellow }}/>
-          </ListItemIcon>
-          <ListItemText
-            primary={`The following files failed fixity checks: ${transferData.failed_fixity.join(', ')}`}
-          />
-        </ListItem>
+            <ListItemIcon>
+              <ErrorOutlineIcon style={{ color: colors.warningYellow }}/>
+            </ListItemIcon>
+            <ListItemText
+              primary='Fixity check can not be performed as Github does not expose file checksums. '
+            />
+          </ListItem>
+        : uploadData.failed_fixity.length > 0
+        ? < ListItem >
+            <ListItemIcon>
+              <ErrorOutlineIcon style={{ color: colors.warningYellow }}/>
+            </ListItemIcon>
+            <ListItemText
+              primary={`The following files failed fixity checks: ${uploadData.failed_fixity.join(', ')}`}
+            />
+          </ListItem>
         : <ListItem>
-          <ListItemIcon>
-            <CheckCircleOutlineIcon style={{ color: colors.successGreen }}/>
-          </ListItemIcon>
-          <ListItemText
-            primary='All files passed fixity checks'
-          />
-        </ListItem>;
+            <ListItemIcon>
+              <CheckCircleOutlineIcon style={{ color: colors.successGreen }}/>
+            </ListItemIcon>
+            <ListItemText
+              primary='All files passed fixity checks'
+            />
+          </ListItem>;
 
       const resourcesIgnoredMessage = transferData.resources_ignored.length > 0
         ? <ListItem>

--- a/src/components/upload_stepper/UploadResultsContent.js
+++ b/src/components/upload_stepper/UploadResultsContent.js
@@ -71,8 +71,18 @@ export default function UploadResultsContent({setActiveStep, setSelectedFile,
       )
     }
     else if (uploadStatus === 'finished') {
-      const failedFixityMessage = uploadData.failed_fixity.length > 0
+      console.log(connection);
+      const failedFixityMessage = uploadData.failed_fixity.length > 0 && connection.name === 'github'
         ? <ListItem>
+            <ListItemIcon>
+              <ErrorOutlineIcon style={{ color: colors.warningYellow }}/>
+            </ListItemIcon>
+          <ListItemText
+          primary='Fixity check can not be performed as Github does not expose file checksums. '
+        />
+      </ListItem>
+        : uploadData.failed_fixity.length > 0
+        ? < ListItem >
           <ListItemIcon>
             <ErrorOutlineIcon style={{ color: colors.warningYellow }}/>
           </ListItemIcon>


### PR DESCRIPTION
***Work Completed***
- Since GitHub does not expose file checksums, we want a message to relay that information to the user instead of listing out every single file that failed the fixity check.

***Steps Required***
- N/A