### PR TITLE
Branks42 Disable Git Resources(Transfer)

### DIFF
--- a/src/components/transfer/TransferResourceButton.js
+++ b/src/components/transfer/TransferResourceButton.js
@@ -15,6 +15,7 @@ const rectangle = require("../../images/icons/rectangle.png");
 export default function TransferResourceButton({resource, level, onClick }) {
   const transferStepInModal = useSelector(state => state.transferStepInModal);
   const transferStatus = useSelector(state => state.transferStatus);
+  const transferDestinationTarget = useSelector(state => state.transferDestinationTarget);
   const [disabled, setDisabled] = useState(false);
   
   useEffect(() => {
@@ -55,7 +56,10 @@ export default function TransferResourceButton({resource, level, onClick }) {
 
   return (
     <button
-      disabled={resource.kind === 'item' || disabled}
+      disabled={resource.kind === 'item' ||
+        disabled ||
+        ['gitlab', 'github'].indexOf(transferDestinationTarget) > -1
+      }
       css={[{
         display: "flex",
         flexDirection: "row",
@@ -71,7 +75,10 @@ export default function TransferResourceButton({resource, level, onClick }) {
           cursor: 'not-allowed',
         }
       },
-        resource.kind === 'item' ? { opacity: 0.5 } : null
+        resource.kind === 'item' ||
+        ['gitlab', 'github'].indexOf(transferDestinationTarget) > -1
+          ? { opacity: 0.5 }
+          : null
       ]}
       onClick={() => onClick(resource)}
     >

--- a/src/components/transfer/stepper/TransferStepper.js
+++ b/src/components/transfer/stepper/TransferStepper.js
@@ -81,6 +81,7 @@ export default function TransferStepper() {
   const handleBack = () => {
     if (activeStep === 2){
       dispatch(actionCreators.transfer.clearTransferToken());
+      dispatch(actionCreators.transfer.clearTransferTargetResources());
     }
     dispatch(actionCreators.transfer.stepInTransferModal(activeStep - 1));
     setActiveStep(prevActiveStep => prevActiveStep - 1);

--- a/src/redux/actionCreators.js
+++ b/src/redux/actionCreators.js
@@ -91,6 +91,7 @@ export const actionCreators = createActions({
         CLEAR_TRANSFER_DATA: undefined,
         CLEAR_TRANSFER_TOKEN: undefined,
         CLEAR_TRANSFER_RESOURCE: undefined,
+        CLEAR_TRANSFER_TARGET_RESOURCES: undefined,
         REFRESH_TRANSFER_TARGET: (target, targetToken) => ({target, targetToken}),
         REFRESH_TRANSFER_TARGET_SUCCESS: undefined,
         REFRESH_TRANSFER_TARGET_FAILURE: (status, data) => ({ status, data }),

--- a/src/redux/reducers/transfer.js
+++ b/src/redux/reducers/transfer.js
@@ -350,6 +350,13 @@ export const transferReducers = {
       )
     }),
     /**
+     * Clear the transfer target resources
+     **/
+    [actionCreators.transfer.clearTransferTargetResources]: state => ({
+      ...state,
+      transferTargetResources: null
+    }),
+    /**
      * Refresh the resources in the Transfer Resource Browser.
      * Saga call to Resource-Collection occurs with this action.
      **/


### PR DESCRIPTION
***Work Completed***
- Resources are disabled to transfer into if transfer destination target is GitHub or GitLab
- New action to clear resources if user presses back on resource selection step in transfer modal

***Steps Required***
- N/A